### PR TITLE
CVE-2026-4847-cap-set-file-toctou

### DIFF
--- a/Regression/CVE-2026-4878-cap-set-file-toctou/main.fmf
+++ b/Regression/CVE-2026-4878-cap-set-file-toctou/main.fmf
@@ -1,0 +1,14 @@
+summary: Regression test for CVE-2026-4878 in cap_set_file()
+description: ''
+contact: Adam Prikryl <aprikryl@redhat.com>
+component:
+  - libcap
+test: ./runtest.sh
+recommend:
+  - libcap
+duration: 5m
+enabled: true
+tag:
+  - CI-Tier-1
+  - Tier1
+tier: '1'

--- a/Regression/CVE-2026-4878-cap-set-file-toctou/runtest.sh
+++ b/Regression/CVE-2026-4878-cap-set-file-toctou/runtest.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/libcap/Regression/CVE-2026-4878-cap-set-file-toctou
+#   Description: Regression test for cap_set_file() TOCTOU hardening.
+#   Author: Adam Prikryl <aprikryl@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2026 Red Hat, Inc.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 2 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="libcap"
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlAssertRpm "${PACKAGE}" || rlDie
+        rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
+        rlRun "pushd ${TmpDir}"
+        rlRun "cp /bin/true ./privileged"
+        rlRun "chmod 0000 ./privileged"
+        rlRun "ln -s ./privileged ./unprivileged"
+    rlPhaseEnd
+
+    rlPhaseStartTest "setcap succeeds on unreadable regular file"
+        rlRun "setcap cap_setuid,cap_setgid=ei ./privileged" 0 \
+            "setcap must still work through fallback path"
+        rlRun -s "getcap ./privileged" 0
+        rlAssertGrep "privileged [= ]*cap_setgid,cap_setuid[+=]ei" \
+            "${rlRun_LOG}" -E
+    rlPhaseEnd
+
+    rlPhaseStartTest "setcap -r rejects symlink path"
+        rlRun "setcap -r ./unprivileged" 1 \
+            "removing capabilities via symlink must fail"
+        rlRun -s "getcap ./privileged" 0
+        rlAssertGrep "privileged [= ]*cap_setgid,cap_setuid[+=]ei" \
+            "${rlRun_LOG}" -E
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "chmod 0755 ./privileged"
+        rlRun "popd"
+        rlRun "rm -rf ${TmpDir}" 0 "Removing tmp directory"
+    rlPhaseEnd
+rlJournalPrintText
+rlJournalEnd

--- a/Regression/CVE-2026-4878-cap-set-file-toctou/runtest.sh
+++ b/Regression/CVE-2026-4878-cap-set-file-toctou/runtest.sh
@@ -43,15 +43,21 @@ rlJournalStart
         rlRun "setcap cap_setuid,cap_setgid=ei ./privileged" 0 \
             "setcap must still work through fallback path"
         rlRun -s "getcap ./privileged" 0
-        rlAssertGrep "privileged [= ]*cap_setgid,cap_setuid[+=]ei" \
+        rlAssertGrep "privileged [= ].*cap_setuid" \
+            "${rlRun_LOG}" -E
+        rlAssertGrep "privileged [= ].*cap_setgid" \
             "${rlRun_LOG}" -E
     rlPhaseEnd
 
     rlPhaseStartTest "setcap -r rejects symlink path"
-        rlRun "setcap -r ./unprivileged" 1 \
+        rlRun -s "setcap -r ./unprivileged" 1 \
             "removing capabilities via symlink must fail"
+        rlAssertGrep "unprivileged.*(Invalid argument|not a regular file|symlink|symbolic link)" \
+            "${rlRun_LOG}" -E
         rlRun -s "getcap ./privileged" 0
-        rlAssertGrep "privileged [= ]*cap_setgid,cap_setuid[+=]ei" \
+        rlAssertGrep "privileged [= ].*cap_setuid" \
+            "${rlRun_LOG}" -E
+        rlAssertGrep "privileged [= ].*cap_setgid" \
             "${rlRun_LOG}" -E
     rlPhaseEnd
 


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Add beakerlib regression test ensuring setcap succeeds on unreadable regular files and rejects capability removal via symlinks for cap_set_file() TOCTOU fix.