### PR TITLE
Revert sourcery.ai changes that broke getcap regex matching

### DIFF
--- a/Regression/CVE-2026-4878-cap-set-file-toctou/runtest.sh
+++ b/Regression/CVE-2026-4878-cap-set-file-toctou/runtest.sh
@@ -43,21 +43,15 @@ rlJournalStart
         rlRun "setcap cap_setuid,cap_setgid=ei ./privileged" 0 \
             "setcap must still work through fallback path"
         rlRun -s "getcap ./privileged" 0
-        rlAssertGrep "privileged [= ].*cap_setuid" \
-            "${rlRun_LOG}" -E
-        rlAssertGrep "privileged [= ].*cap_setgid" \
+        rlAssertGrep "privileged [= ]*cap_setgid,cap_setuid[+=]ei" \
             "${rlRun_LOG}" -E
     rlPhaseEnd
 
     rlPhaseStartTest "setcap -r rejects symlink path"
-        rlRun -s "setcap -r ./unprivileged" 1 \
+        rlRun "setcap -r ./unprivileged" 1 \
             "removing capabilities via symlink must fail"
-        rlAssertGrep "unprivileged.*(Invalid argument|not a regular file|symlink|symbolic link)" \
-            "${rlRun_LOG}" -E
         rlRun -s "getcap ./privileged" 0
-        rlAssertGrep "privileged [= ].*cap_setuid" \
-            "${rlRun_LOG}" -E
-        rlAssertGrep "privileged [= ].*cap_setgid" \
+        rlAssertGrep "privileged [= ]*cap_setgid,cap_setuid[+=]ei" \
             "${rlRun_LOG}" -E
     rlPhaseEnd
 


### PR DESCRIPTION
## Summary by Sourcery

Update capability regression test expectations to match the current getcap output format and simplify the symlink failure check.

Tests:
- Adjust getcap regex assertions to validate combined cap_setgid and cap_setuid capability strings in a single check.
- Simplify the setcap -r symlink rejection test by relying on exit status instead of matching specific error messages.