### PR TITLE
Regression/CVE-2026-4878 - Test strengthened

### DIFF
--- a/Regression/CVE-2026-4878-cap-set-file-toctou/main.fmf
+++ b/Regression/CVE-2026-4878-cap-set-file-toctou/main.fmf
@@ -1,11 +1,15 @@
 summary: Regression test for CVE-2026-4878 in cap_set_file()
-description: ''
+description: |
+    Verifies CVE-2026-4878 TOCTOU fix in cap_set_file() by checking that
+    setcap uses fd-based xattr operations (fsetxattr/fremovexattr) instead
+    of path-based operations, and that symlink paths are rejected.
 contact: Adam Prikryl <aprikryl@redhat.com>
 component:
   - libcap
 test: ./runtest.sh
-recommend:
+require:
   - libcap
+  - strace
 duration: 5m
 enabled: true
 tag:

--- a/Regression/CVE-2026-4878-cap-set-file-toctou/runtest.sh
+++ b/Regression/CVE-2026-4878-cap-set-file-toctou/runtest.sh
@@ -32,31 +32,69 @@ PACKAGE="libcap"
 rlJournalStart
     rlPhaseStartSetup
         rlAssertRpm "${PACKAGE}" || rlDie
+        rlAssertRpm "strace" || rlDie
         rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
         rlRun "pushd ${TmpDir}"
-        rlRun "cp /bin/true ./privileged"
-        rlRun "chmod 0000 ./privileged"
-        rlRun "ln -s ./privileged ./unprivileged"
+        # testbin must stay readable: patched cap_set_file() takes the
+        # O_RDONLY|O_NOFOLLOW fast path → fsetxattr/fremovexattr on the fd.
+        # chmod 0000 would force the O_PATH fallback that uses
+        # setxattr/removexattr on /proc/self/fd/N — still secure, but
+        # the fsetxattr/fremovexattr assertions below would not match.
+        rlRun "cp /bin/true ./testbin"
+        rlRun "cp /bin/true ./symtarget"
+        rlRun "setcap cap_setuid,cap_setgid=ei ./symtarget" 0
+        rlRun "ln -s ./symtarget ./symlink"
     rlPhaseEnd
 
-    rlPhaseStartTest "setcap succeeds on unreadable regular file"
-        rlRun "setcap cap_setuid,cap_setgid=ei ./privileged" 0 \
-            "setcap must still work through fallback path"
-        rlRun -s "getcap ./privileged" 0
-        rlAssertGrep "privileged [= ]*cap_setgid,cap_setuid[+=]ei" \
-            "${rlRun_LOG}" -E
+    # The CVE-2026-4878 fix replaces path-based lstat()+setxattr(path)
+    # with fd-based open(O_NOFOLLOW)+fsetxattr(fd), eliminating the
+    # TOCTOU window.  The next three phases verify this by inspecting
+    # the actual syscalls setcap makes.  They FAIL on unpatched builds
+    # (which never call fsetxattr/fremovexattr or open with O_NOFOLLOW)
+    # and PASS only when the fix is present.
+
+    rlPhaseStartTest "CVE-2026-4878: cap_set_file opens target with O_NOFOLLOW"
+        rlRun "strace -o ./trace_open.log -e trace=openat \
+            setcap cap_net_raw=ep ./testbin" 0
+        rlLog "=== strace openat trace ==="
+        rlRun "cat ./trace_open.log"
+        rlAssertGrep 'testbin.*O_NOFOLLOW' ./trace_open.log
     rlPhaseEnd
 
-    rlPhaseStartTest "setcap -r rejects symlink path"
-        rlRun "setcap -r ./unprivileged" 1 \
+    rlPhaseStartTest "CVE-2026-4878: cap_set_file uses fd-based fsetxattr"
+        rlRun "strace -o ./trace_fset.log -e trace=setxattr,fsetxattr \
+            setcap cap_net_raw=ep ./testbin" 0
+        rlLog "=== strace setxattr trace ==="
+        rlRun "cat ./trace_fset.log"
+        rlAssertGrep 'fsetxattr' ./trace_fset.log
+        rlRun -s "getcap ./testbin" 0
+        rlAssertGrep "cap_net_raw" "${rlRun_LOG}"
+    rlPhaseEnd
+
+    rlPhaseStartTest "CVE-2026-4878: cap_set_file -r uses fd-based fremovexattr"
+        rlRun "setcap cap_net_raw=ep ./testbin" 0 "ensure capabilities are set"
+        rlRun "strace -o ./trace_frem.log -e trace=removexattr,fremovexattr \
+            setcap -r ./testbin" 0
+        rlLog "=== strace removexattr trace ==="
+        rlRun "cat ./trace_frem.log"
+        rlAssertGrep 'fremovexattr' ./trace_frem.log
+        rlRun -s "getcap ./testbin" 0
+        rlAssertNotGrep "cap_net_raw" "${rlRun_LOG}"
+    rlPhaseEnd
+
+    rlPhaseStartTest "setcap rejects setting capabilities via symlink"
+        rlRun "setcap cap_net_raw=ep ./symlink" 1 \
+            "setting capabilities via symlink must fail"
+    rlPhaseEnd
+
+    rlPhaseStartTest "setcap -r rejects symlink and preserves target capabilities"
+        rlRun "setcap -r ./symlink" 1 \
             "removing capabilities via symlink must fail"
-        rlRun -s "getcap ./privileged" 0
-        rlAssertGrep "privileged [= ]*cap_setgid,cap_setuid[+=]ei" \
-            "${rlRun_LOG}" -E
+        rlRun -s "getcap ./symtarget" 0
+        rlAssertGrep "cap_setgid,cap_setuid" "${rlRun_LOG}"
     rlPhaseEnd
 
     rlPhaseStartCleanup
-        rlRun "chmod 0755 ./privileged"
         rlRun "popd"
         rlRun "rm -rf ${TmpDir}" 0 "Removing tmp directory"
     rlPhaseEnd


### PR DESCRIPTION
## Summary by Sourcery

Strengthen the CVE-2026-4878 regression test to validate fd-based, O_NOFOLLOW-cap_set_file behavior and symlink rejection semantics.

Bug Fixes:
- Adjust the regression test to correctly exercise and assert the patched cap_set_file behavior using fd-based operations, avoiding reliance on the fallback path.

Enhancements:
- Extend the regression test to verify openat uses O_NOFOLLOW and that setcap/getcap rely on fsetxattr/fremovexattr rather than path-based setxattr, using strace for syscall inspection.
- Refine test setup to use a readable test binary and explicit symlink/target files, and update assertions to ensure capabilities remain on the symlink target when -r via symlink is rejected.
- Add explicit checks that setcap refuses setting or removing capabilities via symlink paths while preserving target capabilities.

Tests:
- Add new strace-driven subtests that validate openat O_NOFOLLOW usage and fd-based fsetxattr/fremovexattr calls as part of the CVE-2026-4878 regression coverage.